### PR TITLE
Add interface for contextual environments

### DIFF
--- a/alr_envs/utils/contextual_env.py
+++ b/alr_envs/utils/contextual_env.py
@@ -1,0 +1,20 @@
+from abc import abstractmethod
+from typing import Union, Tuple
+
+import numpy as np
+from gym import Env
+
+class ContextualEnv(Env):
+    """A contextual environment. It functions just as any regular OpenAI Gym environment but it includes
+    a context space and a method to set the context of the environment.
+    """
+    context_space = None # :gym.spaces
+
+    @abstractmethod
+    def set_context(self, context: Union[Tuple, float, np.ndarray, int]):
+        """Set the environments context. This externalizes the context selection and allows
+        to include learning of its distribution
+
+        :param context: Context to be applied onto the environment
+        """
+        raise NotImplementedError


### PR DESCRIPTION
The ContextualEnv is defined similar to the [GoalEnv](https://github.com/openai/gym/blob/a5a6ae6bc0a5cfc0ff1ce9be723d59593c165022/gym/core.py#L163)

It defines a context space. As for the action and observation space this could hold any of the [gym.spaces](https://github.com/openai/gym/tree/master/gym/spaces) and similar to `env.action_space.sample()`, samples from the space could be drawn easily. 

As OpenAi gym defines several utility functions for the spaces, also clipping to the context space can easily be done, e.g. if we would like to learn the context distribution and thus could get samples outside of the environments context space.

Similar to the `env.step(env.action_space.sample())` procedure to quickly apply some action to an environment, `env.set_context(env.context_space.sample())` allows for setting a context for the environment. 

Since meaning of the context space and thus also the required procedure to execute when a new context is set, depends completely on the environment, the implementation of the function should also be a responsability of the environment