### PR TITLE
Make get_trajectory work with tensors

### DIFF
--- a/fancy_gym/black_box/black_box_wrapper.py
+++ b/fancy_gym/black_box/black_box_wrapper.py
@@ -84,6 +84,8 @@ class BlackBoxWrapper(gym.ObservationWrapper):
 
         if isinstance(action, torch.Tensor):
             low, high = torch.from_numpy(self.traj_gen_action_space.low), torch.from_numpy(self.traj_gen_action_space.high)
+            if action.is_cuda:
+                low, high = low.cuda(), high.cuda()
             clipped_params = torch.clip(action, low, high)
         else:
             clipped_params = np.clip(action, self.traj_gen_action_space.low, self.traj_gen_action_space.high)

--- a/fancy_gym/black_box/black_box_wrapper.py
+++ b/fancy_gym/black_box/black_box_wrapper.py
@@ -113,7 +113,7 @@ class BlackBoxWrapper(gym.ObservationWrapper):
 
     def _get_traj_gen_action_space(self):
         """This function can be used to set up an individual space for the parameters of the traj_gen."""
-        min_action_bounds, max_action_bounds = self.traj_gen.get_params_bounds()
+        min_action_bounds, max_action_bounds = self.traj_gen.get_params_bounds().cpu()
         action_space = gym.spaces.Box(low=min_action_bounds.numpy(), high=max_action_bounds.numpy(),
                                       dtype=self.env.action_space.dtype)
         return action_space

--- a/fancy_gym/black_box/black_box_wrapper.py
+++ b/fancy_gym/black_box/black_box_wrapper.py
@@ -82,11 +82,11 @@ class BlackBoxWrapper(gym.ObservationWrapper):
             # If we do not do this, the traj_gen assumes we are continuing the trajectory.
             self.traj_gen.reset()
 
-        if isinstance(action, np.ndarray):
-            clipped_params = np.clip(action, self.traj_gen_action_space.low, self.traj_gen_action_space.high)
-        else:
+        if isinstance(action, torch.Tensor):
             low, high = torch.from_numpy(self.traj_gen_action_space.low), torch.from_numpy(self.traj_gen_action_space.high)
             clipped_params = torch.clip(action, low, high)
+        else:
+            clipped_params = np.clip(action, self.traj_gen_action_space.low, self.traj_gen_action_space.high)
         self.traj_gen.set_params(clipped_params)
         bc_time = np.array(0 if not self.do_replanning else self.current_traj_steps * self.dt)
         # TODO we could think about initializing with the previous desired value in order to have a smooth transition
@@ -98,7 +98,7 @@ class BlackBoxWrapper(gym.ObservationWrapper):
         position = self.traj_gen.get_traj_pos()
         velocity = self.traj_gen.get_traj_vel()
 
-        if isinstance(action, np.ndarray):
+        if not isinstance(action, torch.Tensor):
             position = get_numpy(position)
             velocity = get_numpy(velocity)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     extras_require=extras,
     install_requires=[
-        'gym[mujoco]<0.25.0,>=0.24.0',
+        'gym[mujoco]<0.25.0,>=0.24.1',
         'mp_pytorch @ git+https://github.com/ALRhub/MP_PyTorch.git@main'
     ],
     packages=[package for package in find_packages() if package.startswith("fancy_gym")],


### PR DESCRIPTION
This change makes the get_trajectory method of the black-box environments work with PyTorch tensors without numpy operations, such that gradients can pass through. It doesn't change the behavior if called with anything other than a tensor.

Running on GPU works with this fix: https://github.com/ALRhub/MP_PyTorch/pull/84