### PR TITLE
Fix `pip install ".[metaworld]"`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 # Environment-specific dependencies for dmc and metaworld
 extras = {
     'dmc': ['shimmy[dm-control]', 'Shimmy==1.0.0'],
-    'metaworld': ['metaworld @ git+https://github.com/Farama-Foundation/Metaworld.git@d155d0051630bb365ea6a824e02c66c068947439#egg=metaworld'],
+    'metaworld': ['mujoco==2.3.3', 'metaworld @ git+https://github.com/Farama-Foundation/Metaworld.git@d155d0051630bb365ea6a824e02c66c068947439#egg=metaworld'],
     'box2d': ['gymnasium[box2d]>=0.26.0'],
     'mujoco': ['mujoco==2.3.3', 'gymnasium[mujoco]>0.26.0'],
     'mujoco-legacy': ['mujoco-py >=2.1,<2.2', 'cython<3'],


### PR DESCRIPTION
Hi! If you install fancy_gym with `pip install ".[metaworld]"`,
it fetches MuJoCo in version 3.0.0 which seems incompatible,
causing `import fancy_gym` to throw an exception.

You can use this docker file to reproduce:

```dockerfile
from fedora:38

run dnf install -y clang cmake python3-pip git glfw && dnf clean -y all

run mkdir /workdir
workdir /workdir

run git clone https://github.com/ALRhub/fancy_gym.git

run cd fancy_gym && git checkout master && pip install ".[metaworld]"

cmd cd / && python3 -c "import fancy_gym"
```