### PR TITLE
Implemented render_mode 'rgb_array' for AirHockeyEnv

### DIFF
--- a/fancy_gym/envs/mujoco/air_hockey/air_hockey_env_wrapper.py
+++ b/fancy_gym/envs/mujoco/air_hockey/air_hockey_env_wrapper.py
@@ -8,7 +8,7 @@ from fancy_gym.envs.mujoco.air_hockey.utils import robot_to_world
 from mushroom_rl.core import Environment
 
 class AirHockeyEnv(Environment):
-    metadata = {"render_modes": ["human"], "render_fps": 50}
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 50}
 
     def __init__(self, env_mode=None, interpolation_order=3, render_mode=None, **kwargs):
         """
@@ -38,6 +38,18 @@ class AirHockeyEnv(Environment):
 
         if env_mode == "tournament" and type(interpolation_order) != tuple:
             interpolation_order = (interpolation_order, interpolation_order)
+
+        self.render_mode = render_mode
+
+        # Determine headless mode based on render_mode
+        headless = self.render_mode == 'rgb_array'
+        width = kwargs.pop('width', 1920)
+        height = kwargs.pop('height', 1080)
+        
+        # Prepare viewer_params
+        viewer_params = kwargs.get('viewer_params', {})
+        viewer_params.update({'headless': headless, 'width': width, 'height': height})
+        kwargs['viewer_params'] = viewer_params
 
         self.base_env = env_dict[env_mode](interpolation_order=interpolation_order, **kwargs)
         self.env_name = env_mode
@@ -81,9 +93,6 @@ class AirHockeyEnv(Environment):
         self.env_info['constraints'] = constraint_list
         self.env_info['env_name'] = self.env_name
 
-        self.render_mode = render_mode
-        self.render_human_active = False
-
         super().__init__(self.base_env.info)
 
     def step(self, action):
@@ -111,15 +120,17 @@ class AirHockeyEnv(Environment):
 
         if self.env_info['env_name'] == "tournament":
             obs = np.array(np.split(obs, 2))
-        
-        if self.render_human_active:
-            self.base_env.render()
 
         return obs, reward, done, False, info
 
     def render(self):
-        self.render_human_active = True
-
+        if self.render_mode == 'rgb_array':
+            return self.base_env.render(record = True)
+        elif self.render_mode == 'human':
+            self.base_env.render()
+        else:
+            raise ValueError(f"Unsupported render mode: '{self.render_mode}'")
+            
     def reset(self, seed=None, options={}):
         self.base_env.seed(seed)
         obs = self.base_env.reset()

--- a/fancy_gym/envs/mujoco/air_hockey/air_hockey_env_wrapper.py
+++ b/fancy_gym/envs/mujoco/air_hockey/air_hockey_env_wrapper.py
@@ -10,7 +10,7 @@ from mushroom_rl.core import Environment
 class AirHockeyEnv(Environment):
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 50}
 
-    def __init__(self, env_mode=None, interpolation_order=3, render_mode=None, **kwargs):
+    def __init__(self, env_mode=None, interpolation_order=3, render_mode=None, width=1920, height=1080, **kwargs):
         """
         Environment Constructor
 
@@ -40,11 +40,10 @@ class AirHockeyEnv(Environment):
             interpolation_order = (interpolation_order, interpolation_order)
 
         self.render_mode = render_mode
+        self.render_human_active = False
 
         # Determine headless mode based on render_mode
         headless = self.render_mode == 'rgb_array'
-        width = kwargs.pop('width', 1920)
-        height = kwargs.pop('height', 1080)
         
         # Prepare viewer_params
         viewer_params = kwargs.get('viewer_params', {})
@@ -121,13 +120,16 @@ class AirHockeyEnv(Environment):
         if self.env_info['env_name'] == "tournament":
             obs = np.array(np.split(obs, 2))
 
+        if self.render_human_active:
+            self.base_env.render()
+
         return obs, reward, done, False, info
 
     def render(self):
         if self.render_mode == 'rgb_array':
             return self.base_env.render(record = True)
         elif self.render_mode == 'human':
-            self.base_env.render()
+            self.render_human_active = True
         else:
             raise ValueError(f"Unsupported render mode: '{self.render_mode}'")
             

--- a/fancy_gym/envs/mujoco/air_hockey/air_hockey_env_wrapper.py
+++ b/fancy_gym/envs/mujoco/air_hockey/air_hockey_env_wrapper.py
@@ -130,6 +130,7 @@ class AirHockeyEnv(Environment):
             return self.base_env.render(record = True)
         elif self.render_mode == 'human':
             self.render_human_active = True
+            self.base_env.render()
         else:
             raise ValueError(f"Unsupported render mode: '{self.render_mode}'")
             


### PR DESCRIPTION
- implemented rgb_array render mode for off-screen rendering in the AirHockeyEnvironment-Wrapper

- Use Case: when creating an AirHockey environment, the user can specify a render_mode and width and height of the rendered frames
- Example Code:
```env = gym.make('fancy/AirHockey-3dof-hit-v0', render_mode="rgb_array", width=600, height=400)```

