### PR TITLE
Add toml to build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.7"
 #"Repository" = "https://github.com/ALRhub/fancy_gym/"
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel"]
+requires = ["setuptools>=61.0.0", "wheel", "toml"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Without this change `pip install .` fails in a fresh conda env (tested with both python 3.7 and 3.11 on my mac).